### PR TITLE
Fix: error with C programs saying import_coc4...waitClient not a func

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ var log: Logger
 
 async function getService(id: string): Promise<IServiceProvider> {
 	// @ts-expect-error
-	await services.waitClient(id)
+	await services.getLanguageClient(id)
 	return services.getService(id)
 }
 


### PR DESCRIPTION
I kept getting the following error whenever I would open a `C` file.

```
[coc.nvim]: UnhandledRejection: TypeError: import_coc4.services.waitClient is not a function
```

There very well could be other issues.

I'm not sure if you use this program anymore, but I had used some of the functions that you had from your Neovim dotfiles and one of the functions provides an outline with the function `kvs.symbol.docSymbols`. I don't know how to get a custom function in the quickfix window without this plugin.

Thanks.